### PR TITLE
Consider corners as edges

### DIFF
--- a/tests/test_imageruler.py
+++ b/tests/test_imageruler.py
@@ -433,6 +433,60 @@ class MorphologyOperationsTest(unittest.TestCase):
         )
         onp.testing.assert_array_equal(expected, actual)
 
+    def test_detect_edges(self):
+        x = onp.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1],
+                [0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1],
+                [0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+            dtype=bool,
+        )
+        expected = onp.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 1],
+                [0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 0],
+                [0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+            dtype=bool,
+        )
+        onp.testing.assert_array_equal(
+            imageruler.detect_edges(x, periodic=(False, False)), expected
+        )
+
+    def test_detect_edges_periodic(self):
+        x = onp.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1],
+                [0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1],
+                [0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+            dtype=bool,
+        )
+        expected = onp.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 1],
+                [0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 1],
+                [0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+            dtype=bool,
+        )
+        onp.testing.assert_array_equal(
+            imageruler.detect_edges(x, periodic=(True, True)), expected
+        )
+
     def test_opening_removes_small_features(self):
         # Test that a feature that is feasible with a size-4 brush is eliminated
         # by opening with the size-5 brush.


### PR DESCRIPTION
The previous `LARGE_FEATURE_EDGES_STRICT` scheme actually did not consider corners ("diagonal edges") as edges. This PR relaxes the scheme so that corners are properly treated as edges. As before, checkerboard features are not considered edges.